### PR TITLE
CCP-1769: Renamed exposed custom data key to backInStockCustomData

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,18 +4,10 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](http://keepachangelog.com/) and this project adheres to [Semantic Versioning](http://semver.org/).
 
-## [Unreleased]
+## [1.0.1] - 2018-10-17
 ### Added
-### Changed
-### Fixed
-### Removed
+- Renamed exposed custom data key to backInStockCustomData
 
-## [1.0.0] - YYYY-MM-DD
+## [1.0.0] - 2018-04-01
 ### Added
-### Changed
-### Fixed
-### Removed
-
-
-[Unreleased]: https://github.com/shopgate/ext-cliplister/compare/v1.0.0...HEAD
-[1.0.0]: https://github.com/shopgate/ext-cliplister/compare/v0.0.1...v1.0.0
+- Initial release of Back In Stock Integration

--- a/extension-config.json
+++ b/extension-config.json
@@ -1,5 +1,5 @@
 {
-  "version": "1.0.0",
+  "version": "1.0.1",
   "id": "@shopgate-project/shopify-back-in-stock",
   "components": [
     {
@@ -97,7 +97,9 @@
   "steps": [
     {
       "path": "extension/steps/exposeCustomDataToGetProduct.js",
-      "hooks": ["shopgate.catalog.getProduct.v1:afterFetchProducts"],
+      "hooks": [
+        "shopgate.catalog.getProduct.v1:afterFetchProducts"
+      ],
       "input": [
         {
           "key": "products"
@@ -105,7 +107,7 @@
       ],
       "output": [
         {
-          "key": "customData",
+          "key": "backInStockCustomData",
           "addPipelineOutput": true
         }
       ]

--- a/extension/package.json
+++ b/extension/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@shopgate-project/shopify-back-in-stock",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "",
   "license": "Apache-2.0",
   "scripts": {

--- a/extension/steps/exposeCustomDataToGetProduct.js
+++ b/extension/steps/exposeCustomDataToGetProduct.js
@@ -1,5 +1,5 @@
 module.exports = async (context, { products }) => {
   const { customData } = products[0] || {}
 
-  return { customData }
+  return { backInStockCustomData: customData }
 }

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@shopgate-project/shopify-back-in-stock",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "",
   "license": "Apache-2.0",
   "scripts": {
@@ -13,11 +13,11 @@
   },
   "devDependencies": {
     "@shopgate/eslint-config": "*",
-    "@shopgate/pwa-common": "^6.3.1",
-    "@shopgate/pwa-common-commerce": "^6.3.1",
-    "@shopgate/pwa-core": "^6.3.1",
+    "@shopgate/pwa-common": "^6.7.2",
+    "@shopgate/pwa-common-commerce": "^6.7.2",
+    "@shopgate/pwa-core": "^6.7.2",
     "jest": "^22.4.2",
-    "@shopgate/pwa-unit-test": "^6.3.1",
+    "@shopgate/pwa-unit-test": "^6.7.2",
     "babel-core": "^6.26.0",
     "babel-plugin-react-transform": "^3.0.0",
     "babel-plugin-transform-class-properties": "^6.24.1",
@@ -29,8 +29,8 @@
     "babel-preset-react": "^6.24.1",
     "eslint": "^4.19.1",
     "prop-types": "^15.6.0",
-    "react": "^16.2.0",
-    "react-dom": "^16.2.0",
+    "react": "~16.8.4",
+    "react-dom": "~16.8.4",
     "react-hot-loader": "^3.1.3",
     "react-transform-catch-errors": "^1.0.2"
   },

--- a/frontend/selectors/index.js
+++ b/frontend/selectors/index.js
@@ -20,7 +20,7 @@ export const getShopifyVariant = createSelector(
   getProductById,
   (product) => {
     const { productData } = product || {};
-    const { customData } = productData || {};
+    const customData = productData.customData || productData.backInStockCustomData;
     const customDataObject = parseJson(customData);
     const { variant_id: shopifyVariantId } = customDataObject || {};
     return shopifyVariantId ? `${shopifyVariantId}` : null;

--- a/frontend/selectors/index.js
+++ b/frontend/selectors/index.js
@@ -24,7 +24,7 @@ export const getShopifyVariant = createSelector(
     * CustomData contains shopifyVariantId with getProducts pipeline
     * backInStockCustomData exposes customData after getProduct pipeline call.
     * backInStockCustomData needs a different name then customData
-    * incase of additional need for customData exposure in separate extensions.
+    * in case of additional need for customData exposure in separate extensions.
     */
     const customData = productData.customData || productData.backInStockCustomData;
 

--- a/frontend/selectors/index.js
+++ b/frontend/selectors/index.js
@@ -19,8 +19,19 @@ import parseJson from '../helpers/parseJson';
 export const getShopifyVariant = createSelector(
   getProductById,
   (product) => {
-    const { productData } = product || {};
+    const { productData = {} } = product || {};
+    /**
+    * CustomData contains shopifyVariantId with getProducts pipeline
+    * backInStockCustomData exposes customData after getProduct pipeline call.
+    * backInStockCustomData needs a different name then customData
+    * incase of additional need for customData exposure in separate extensions.
+    */
     const customData = productData.customData || productData.backInStockCustomData;
+
+    if (!customData) {
+      return null;
+    }
+
     const customDataObject = parseJson(customData);
     const { variant_id: shopifyVariantId } = customDataObject || {};
     return shopifyVariantId ? `${shopifyVariantId}` : null;

--- a/frontend/selectors/index.spec.js
+++ b/frontend/selectors/index.spec.js
@@ -120,7 +120,7 @@ describe('Selectors', () => {
 
     it('should return null', () => {
       const result
-              = getInStockNotificationConfirmationMessage(MOCK_EMPTY_IN_STOCK_STATE, MOCK_PROPS);
+        = getInStockNotificationConfirmationMessage(MOCK_EMPTY_IN_STOCK_STATE, MOCK_PROPS);
       expect(result).toEqual(null);
     });
   });
@@ -132,7 +132,7 @@ describe('Selectors', () => {
 
     it('should return null', () => {
       const result
-              = getInStockNotificationConfirmationStatus(MOCK_EMPTY_IN_STOCK_STATE, MOCK_PROPS);
+        = getInStockNotificationConfirmationStatus(MOCK_EMPTY_IN_STOCK_STATE, MOCK_PROPS);
       expect(result).toEqual(null);
     });
   });
@@ -144,7 +144,7 @@ describe('Selectors', () => {
 
     it('should return null', () => {
       const result
-              = getInStockNotificationConfirmationisFetching(MOCK_EMPTY_IN_STOCK_STATE, MOCK_PROPS);
+        = getInStockNotificationConfirmationisFetching(MOCK_EMPTY_IN_STOCK_STATE, MOCK_PROPS);
       expect(result).toEqual(false);
     });
   });


### PR DESCRIPTION
Test with configs listed in README and shop no:31862.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] This change requires a documentation update

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I updated the CHANGELOG.md